### PR TITLE
Update plugin POM version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.4</version>
+        <version>3.15</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
### Problem

The [parent POM for Jenkins plugins](https://github.com/jenkinsci/plugin-pom) is out of date.

### Solution

Update to the latest version.

### Testing

Ran `mvn package`.