### PR TITLE
Add Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+buildPlugin()


### PR DESCRIPTION
### Problem

There is no `Jenkinsfile`, so builds and tests can't be done on [ci.jenkins.io](https://ci.jenkins.io/).

### Solution

Add a `Jenkinsfile` using the [Pipeline Global Library](https://github.com/jenkins-infra/pipeline-library) to set up builds on the Jenkins-on-Jenkins CI server.

### Next steps

Once this build is passing, I'll add a badge to the `README`.