### PR TITLE
Add build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Delphix Plugin
 
+[![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/delphix-plugin/master)](https://ci.jenkins.io/job/Plugins/job/delphix-plugin/)
 [![Jenkins Plugins](https://img.shields.io/jenkins/plugin/v/delphix.svg)](https://plugins.jenkins.io/delphix)
 [![License](https://img.shields.io/github/license/jenkinsci/delphix-plugin.svg)](LICENSE)
 


### PR DESCRIPTION
### Problem

The `README` doesn't have a badge indicating the current build status.

### Solution

Add a build status badge pointing to [the Jenkins job for the plugin on ci.jenkins.io](https://ci.jenkins.io/job/Plugins/job/delphix-plugin/).