### PR TITLE
Add compatibility testing to automated build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(jenkinsVersions: [null, '2.121.1'])


### PR DESCRIPTION
### Problem

Now that the minimum Jenkins version is 1.651, the automated build only performs testing against this old version. But it would also be helpful to perform testing against a modern version. Modern versions still support all old APIs, but frequently support them through compatibility layers that are not as well tested.

### Solution

Add the latest version to the matrix of Jenkins baseline versions to build/test against in parallel. Note that `null` means the default version of 1.651, while 2.121.1 is the latest version).